### PR TITLE
Read webhook secret from config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # Base URL for webhook server (no trailing slash)
 WEBHOOK_BASE=https://your-backend.example.com
+WEBHOOK_SECRET=replace-with-your-secret

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Static pages for connecting wallets and signing transactions across TON, EVM and
 
 ## Setup
 1. Clone the repo
-2. Copy `.env.example` to `.env` and set `WEBHOOK_BASE` to your backend URL
+2. Copy `.env.example` to `.env` and set `WEBHOOK_BASE` and `WEBHOOK_SECRET`
+   to your backend URL and shared secret
 3. Build and run with Docker:
    ```bash
    docker build -t gigi-wallet-signing .
@@ -13,6 +14,7 @@ Static pages for connecting wallets and signing transactions across TON, EVM and
 
 ## Environment Variables
 - `WEBHOOK_BASE` – Base URL of the webhook server used by the pages.
+- `WEBHOOK_SECRET` – Secret used for HMAC signing.
 
 ## Tests
 Install requirements then run `pytest`.

--- a/public/README.md
+++ b/public/README.md
@@ -20,7 +20,8 @@ Multi-chain wallet connection pages for TON, EVM, Solana.
 
 ## Setup
 1. Clone repo  
-2. Update `WEBHOOK_BASE` in `config.js` or via `.env` when building Docker image
+2. Update `WEBHOOK_BASE` and `WEBHOOK_SECRET` in `config.js` or via `.env`
+   when building Docker image
 3. Push to GitHub → deploy to Render
 
 ## Backend (example)

--- a/public/config.js
+++ b/public/config.js
@@ -1,3 +1,4 @@
 window.GIGI_CONFIG = {
-  WEBHOOK_BASE: ''
+  WEBHOOK_BASE: '',
+  WEBHOOK_SECRET: ''
 };

--- a/public/index.html
+++ b/public/index.html
@@ -266,15 +266,21 @@
       }
     });
 
-    // Request server-side signature
+    // Generate HMAC signature using secret from config
     async function generateSignature(payload) {
-      const res = await fetch(`${window.GIGI_CONFIG.WEBHOOK_BASE}/generate-signature`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: payload
-      });
-      const data = await res.json();
-      return data.signature;
+      const secret = window.GIGI_CONFIG.WEBHOOK_SECRET;
+      const encoder = new TextEncoder();
+      const key = await crypto.subtle.importKey(
+        "raw",
+        encoder.encode(secret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"]
+      );
+      const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+      return Array.from(new Uint8Array(signature))
+        .map(b => b.toString(16).padStart(2, "0"))
+        .join("");
     }
 
     // Sign transaction and send webhook


### PR DESCRIPTION
## Summary
- allow secret for signature generation to come from `window.GIGI_CONFIG`
- expose `WEBHOOK_SECRET` field in `config.js`
- document secret usage in READMEs and `.env.example`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b6c0e9048333939b3bc6c2f632c4