### PR TITLE
Add Telegram WebApp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gigi Wallet Signing
 
 Static pages for connecting wallets and signing transactions across TON, EVM and Solana.
+Pages automatically initialise the Telegram Web App when embedded in the bot so MetaMask and Phantom can run inside Telegram.
 
 ## Setup
 1. Clone the repo

--- a/public/evm.html
+++ b/public/evm.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" href="favicon.ico" />
+  <meta property="og:title" content="EVM Transaction | Cosmic Interface" />
+  <meta property="og:description" content="Sign EVM transactions securely with Cosmic Interface." />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="/favicon.ico" />
+  <meta name="twitter:card" content="summary" />
   <title>EVM Transaction | Cosmic Interface</title>
   <script src="https://unpkg.com/ethers@5.7.2/dist/ethers.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
@@ -225,6 +231,10 @@
   <audio id="successSound" src="https://assets.mixkit.co/sfx/download/mixkit-sci-fi-confirmation-914.wav" preload="auto"></audio>
   <script>
     // EVM/MetaMask JS logic, adapted for the new UI
+    if (window.Telegram && window.Telegram.WebApp) {
+      window.Telegram.WebApp.ready();
+      window.Telegram.WebApp.expand();
+    }
     const params = new URLSearchParams(window.location.search);
     const token = params.get("token") || "ETH";
     const chainParam = params.get("chain") || "sepolia";

--- a/public/solana.html
+++ b/public/solana.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" href="favicon.ico" />
+  <meta property="og:title" content="Solana Wallet Signing | Enchanted Interface" />
+  <meta property="og:description" content="Sign Solana transactions securely with Enchanted Interface." />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="/favicon.ico" />
+  <meta name="twitter:card" content="summary" />
   <title>Solana Wallet Signing | Enchanted Interface</title>
   <script src="https://cdn.jsdelivr.net/npm/@solana/web3.js@1.89.0/lib/index.iife.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
@@ -214,6 +220,10 @@
   <audio id="ambientSound" src="https://assets.mixkit.co/sfx/download/mixkit-ambient-mystical-forest-121.wav" preload="auto" loop></audio>
 
   <script>
+    if (window.Telegram && window.Telegram.WebApp) {
+      window.Telegram.WebApp.ready();
+      window.Telegram.WebApp.expand();
+    }
     const params = new URLSearchParams(window.location.search);
     const amount = params.get("amount") || "1";
     const to = params.get("to") || "";


### PR DESCRIPTION
## Summary
- add Telegram WebApp init to MetaMask and Phantom pages
- include OG meta and favicon on EVM and Solana pages
- document Telegram WebApp usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c20c45bc8333b76c94cea68d2403