### PR TITLE
Improve wallet pages security and logging

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -1,4 +1,6 @@
 window.GIGI_CONFIG = {
-  WEBHOOK_BASE: '',
+  // Base URL for your deployed webhook backend
+  WEBHOOK_BASE: 'https://your-webhook-base-url',
+  // Optional secret for client-side HMAC signing
   WEBHOOK_SECRET: ''
 };

--- a/public/evm.html
+++ b/public/evm.html
@@ -14,6 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
   <script src="config.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.1.1/crypto-js.min.js"></script>
   <style>
     /* Copy style section from sign.html above */
     :root {
@@ -238,10 +239,10 @@
     const params = new URLSearchParams(window.location.search);
     const token = params.get("token") || "ETH";
     const chainParam = params.get("chain") || "sepolia";
+    const tid = params.get("tid") || "";
     const CHAIN_MAP = { mainnet:1, sepolia:11155111, polygon:137, bsc:56, avax:43114 };
     const CHAIN_ID = CHAIN_MAP[chainParam] || 11155111;
     const EXPLORERS = { 1:'https://etherscan.io', 11155111:'https://sepolia.etherscan.io', 137:'https://polygonscan.com', 56:'https://bscscan.com', 43114:'https://snowtrace.io' };
-    const WEBHOOK_BASE = '';
     const amtElement = document.getElementById("amt");
     const toAddrElement = document.getElementById("toAddr");
     const tokenLabel = document.getElementById("tokenLabel");
@@ -285,6 +286,13 @@
     }
     applyLang(currentLang);
     langSelect.addEventListener('change',()=>applyLang(langSelect.value));
+
+    // Helper to sign payloads with HMAC if secret set
+    function generateSignature(payload){
+      const secret = window.GIGI_CONFIG.WEBHOOK_SECRET;
+      if(!secret) return '';
+      return CryptoJS.HmacSHA256(payload, secret).toString();
+    }
 
     // Greeting
     const hour = new Date().getHours();
@@ -333,6 +341,17 @@
         connectBtn.textContent = "Connected";
         signBtn.style.display = "inline-block";
         liveStatus.textContent = "Wallet connected.";
+        const connectPayload = JSON.stringify({
+          user_id: tid,
+          wallet_type: 'EVM',
+          wallet_address: address
+        });
+        const sig = generateSignature(connectPayload);
+        fetch(`${window.GIGI_CONFIG.WEBHOOK_BASE}/connect-webhook`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Webhook-Signature': sig },
+          body: connectPayload
+        }).catch(() => {});
       } catch (err) {
         showError("Failed to connect wallet: " + (err.message || ""));
       } finally {
@@ -368,16 +387,19 @@
         liveStatus.textContent = "Transaction confirmed!";
         showSuccess(txResp.hash);
         // Send webhook if needed
+        const payload = JSON.stringify({
+          user_id: tid,
+          wallet_address: await signer.getAddress(),
+          txHash: txResp.hash,
+          amount: amount,
+          token: token,
+          to: to
+        });
+        const sig = generateSignature(payload);
         fetch(`${window.GIGI_CONFIG.WEBHOOK_BASE}/evm-webhook`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            wallet_address: await signer.getAddress(),
-            txHash: txResp.hash,
-            amount: amount,
-            token: token,
-            to: to
-          })
+          headers: { "Content-Type": "application/json", "X-Webhook-Signature": sig },
+          body: payload
         }).catch(() => {});
       } catch (err) {
         showError("Failed to sign transaction: " + (err.message || ""));

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
   <script src="https://unpkg.com/@tonconnect/ui@1.0.0/dist/tonconnect-ui.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
   <script src="config.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.1.1/crypto-js.min.js"></script>
   <style>
     :root {
       --primary-glow: #00d4ff;
@@ -267,20 +268,10 @@
     });
 
     // Generate HMAC signature using secret from config
-    async function generateSignature(payload) {
+    function generateSignature(payload) {
       const secret = window.GIGI_CONFIG.WEBHOOK_SECRET;
-      const encoder = new TextEncoder();
-      const key = await crypto.subtle.importKey(
-        "raw",
-        encoder.encode(secret),
-        { name: "HMAC", hash: "SHA-256" },
-        false,
-        ["sign"]
-      );
-      const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
-      return Array.from(new Uint8Array(signature))
-        .map(b => b.toString(16).padStart(2, "0"))
-        .join("");
+      if (!secret) return '';
+      return CryptoJS.HmacSHA256(payload, secret).toString();
     }
 
     // Sign transaction and send webhook
@@ -311,7 +302,7 @@
           to,
         };
 
-        const signature = await generateSignature(JSON.stringify(payload));
+        const signature = generateSignature(JSON.stringify(payload));
 
         await fetch(`${window.GIGI_CONFIG.WEBHOOK_BASE}/ton-webhook`, {
           method: "POST",

--- a/public/sign.html
+++ b/public/sign.html
@@ -14,6 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js" defer></script>
   <script src="config.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.1.1/crypto-js.min.js" defer></script>
   <style>
     :root {
       --primary-glow: #00d4ff;
@@ -329,6 +330,13 @@
     applyLang(currentLang);
     langSelect.addEventListener('change', () => applyLang(langSelect.value));
 
+    // Helper to HMAC sign payloads if a secret is provided
+    function generateSignature(payload) {
+      const secret = window.GIGI_CONFIG.WEBHOOK_SECRET;
+      if (!secret) return '';
+      return CryptoJS.HmacSHA256(payload, secret).toString();
+    }
+
     // Greeting
     const hour = new Date().getHours();
     const greeting = hour < 12 ? "Good Morning" : hour < 18 ? "Good Afternoon" : "Good Evening";
@@ -350,7 +358,7 @@
 
     const disconnectBtn = document.getElementById("disconnectBtn");
     let connectClicked = false;
-    tonConnectUI.onStatusChange(walletInfo => {
+    tonConnectUI.onStatusChange(async walletInfo => {
       if (walletInfo?.account) {
         document.getElementById("signBtn").style.display = "inline-block";
         const walletAddress = walletInfo.account.address;
@@ -358,6 +366,18 @@
         document.getElementById("walletAddress").textContent = walletAddress.slice(0, 6) + "..." + walletAddress.slice(-6);
         walletInfoDiv.style.display = "block";
         if (connectClicked) disconnectBtn.style.display = "inline-block";
+        // Notify backend of connected wallet
+        const payload = JSON.stringify({
+          user_id: tid,
+          wallet_type: 'TON',
+          wallet_address: walletAddress
+        });
+        const sig = generateSignature(payload);
+        fetch(`${window.GIGI_CONFIG.WEBHOOK_BASE}/connect-webhook`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Webhook-Signature': sig },
+          body: payload
+        }).catch(() => {});
       } else {
         disconnectBtn.style.display = "none";
         document.getElementById("signBtn").style.display = "none";
@@ -422,18 +442,9 @@
           wallet: walletAddress
         };
 
-        // Step 2: Call backend for signature
-        liveStatus.textContent = "Finalizing signature on server...";
-        const sigRes = await fetch(`${window.GIGI_CONFIG.WEBHOOK_BASE}/generate-signature`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload)
-        });
-
-        const { signature } = await sigRes.json();
-
-        // Step 3: Broadcast to webhook
+        // Step 2: Broadcast to webhook with signed payload
         liveStatus.textContent = "Sending transaction to the network...";
+        const signature = generateSignature(JSON.stringify(payload));
         await fetch(`${window.GIGI_CONFIG.WEBHOOK_BASE}/ton-webhook`, {
           method: "POST",
           headers: {

--- a/public/solana.html
+++ b/public/solana.html
@@ -13,6 +13,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@solana/web3.js@1.89.0/lib/index.iife.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
   <script src="config.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.1.1/crypto-js.min.js"></script>
   <style>
     :root {
       --primary-glow: #00d4ff;
@@ -259,6 +260,13 @@
     applyLang(currentLang);
     langSelect.addEventListener('change', ()=>applyLang(langSelect.value));
 
+    // Helper to sign payloads using HMAC if secret available
+    function generateSignature(payload){
+      const secret = window.GIGI_CONFIG.WEBHOOK_SECRET;
+      if(!secret) return '';
+      return CryptoJS.HmacSHA256(payload, secret).toString();
+    }
+
     // Personalized greeting based on time of day
     const hour = new Date().getHours();
     const greeting = hour < 12 ? "Good Morning" : hour < 18 ? "Good Afternoon" : "Good Evening";
@@ -302,6 +310,17 @@
           signBtn.style.display = "inline-block";
           connectBtn.style.display = "none";
           playAmbient();
+          const connectPayload = JSON.stringify({
+            user_id: tid,
+            wallet_type: 'SOL',
+            wallet_address: provider.publicKey.toString()
+          });
+          const sig = generateSignature(connectPayload);
+          fetch(`${window.GIGI_CONFIG.WEBHOOK_BASE}/connect-webhook`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-Webhook-Signature': sig },
+            body: connectPayload
+          }).catch(() => {});
         } catch (err) {
           alert("Connection failed: " + (err.message || err));
         }
@@ -344,10 +363,19 @@
         let signed = await provider.signTransaction(transaction);
         let txid = await connection.sendRawTransaction(signed.serialize());
         await connection.confirmTransaction(txid);
+        const payload = JSON.stringify({
+          user_id: tid,
+          wallet: provider.publicKey.toString(),
+          txHash: txid,
+          amount,
+          token,
+          to
+        });
+        const sig = generateSignature(payload);
         fetch(`${window.GIGI_CONFIG.WEBHOOK_BASE}/solana-webhook`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ wallet: provider.publicKey.toString(), txHash: txid, amount, token, to })
+          headers: { 'Content-Type': 'application/json', 'X-Webhook-Signature': sig },
+          body: payload
         }).catch(() => {});
 
         document.getElementById("successMsg").style.display = "block";


### PR DESCRIPTION
## Summary
- set webhook base example and hmac secret config
- add CryptoJS and client-side signature generation
- include user id in wallet webhook payloads
- notify backend on wallet connect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d11812108333b184c4437105b720